### PR TITLE
Ensure go_package is set for generated protos

### DIFF
--- a/gen/generate.go
+++ b/gen/generate.go
@@ -56,7 +56,7 @@ var VRToProto = map[string]string{
 var SetComplete = map[string]*parse.Attribute{}
 
 // ProtoHeader represents the protocol buffer header for all protos
-const ProtoHeader = "syntax = \"proto3\";"
+const ProtoHeader = "syntax = \"proto3\";\noption go_package = \"github.com/gradienthealth/dicom-protos/protos\";"
 
 // AttributeProto generates the protocol message for an attribute and returns it as a string
 func AttributeProto(a *parse.Attribute) string {
@@ -103,8 +103,7 @@ func AttributeProto(a *parse.Attribute) string {
 // ModuleProto generates the corresponding protocol buffer for the module and writes it to w
 func ModuleProto(module *parse.Module, w io.Writer) {
 	fmt.Fprintf(w, "// %s\n// Link to standard: %s\n", module.Name, module.LinkToStandard)
-	fmt.Fprintln(w, ProtoHeader)
-	fmt.Fprintln(w, "option go_package = \"github.com/gradienthealth/dicom-protos/protos\";")
+	fmt.Fprintln(w, ProtoHeader) 
 	fmt.Fprintln(w, "import \"Sequences.proto\";")
 	fmt.Fprintln(w, "import \"Attributes.proto\";")
 	fmt.Fprintln(w, "")

--- a/protos/Attributes.proto
+++ b/protos/Attributes.proto
@@ -1,4 +1,5 @@
 syntax = "proto3";
+option go_package = "github.com/gradienthealth/dicom-protos/protos";
 
 // DICOM Tag: (0008,0100)
 message CodeValue {

--- a/protos/Makefile
+++ b/protos/Makefile
@@ -1,0 +1,6 @@
+.PHONY: build
+build:
+	protoc -I ./ --proto_path=./ Attributes.proto --go_out=plugins=grpc,paths=source_relative:.	
+	sed -i'.bak' "s|gradienthealth|gradienthealth/$(SERVICE)|g" *.pb.go
+	sed -i'.bak' "s|dicom-protos/|protos/dicom-protos/|g" *.pb.go
+

--- a/protos/Sequences.proto
+++ b/protos/Sequences.proto
@@ -1,4 +1,5 @@
 syntax = "proto3";
+option go_package = "github.com/gradienthealth/dicom-protos/protos";
 import "Attributes.proto";
 
 // DICOM Tag: (0040,0555)


### PR DESCRIPTION
This change ensures that a `go_package` option is added to all protos generated (this closes #22). 